### PR TITLE
OpenDingux optimisations

### DIFF
--- a/makefile.odx
+++ b/makefile.odx
@@ -70,7 +70,7 @@ F_OPTS = -fpermissive -falign-functions -falign-loops -falign-labels -falign-jum
 	-ftree-vectorize -fweb -frename-registers
 
 ifeq "$(OSTYPE)" "gcw0"	
-CFLAGS = -D_GCW0_ -G0 -O3 -march=mips32 -mtune=mips32r2 -Isrc -Isrc/$(MAMEOS) -Isrc/zlib -mhard-float -mbranch-likely -mno-mips16 $(W_OPTS) $(F_OPTS)
+CFLAGS = -D_GCW0_ -G0 -O3 -Isrc -Isrc/$(MAMEOS) -Isrc/zlib $(W_OPTS) $(F_OPTS)
 else
 CFLAGS = -D_GCW0_ -G0 -O3 -march=mips32 -mtune=mips32 -Isrc -Isrc/$(MAMEOS) -Isrc/zlib -msoft-float --mbranch-likely -mno-mips16 $(W_OPTS) $(F_OPTS)
 endif

--- a/src/odx/minimal.h
+++ b/src/odx/minimal.h
@@ -84,6 +84,7 @@ extern void odx_deinit(void);
 extern void odx_set_clock(int mhz);
 extern void odx_set_video_mode(int bpp,int width,int height);
 extern void odx_clear_video();
+extern void odx_clear_video_multibuf();
 
 extern void odx_printf(char* fmt, ...);
 extern void odx_printf_init(void);


### PR DESCRIPTION
I attach 3 commits that optimise the OpenDingux build of MAME4ALL:
- One of the commits is aimed at reducing audio underruns causing crackling, by buffering a bit more of the audio at once. This introduces a bit of lag in the audio (1 SDL buffer's worth, which is about 20 milliseconds).
- One of the commits is aimed at requesting triple-buffering on OpenDingux for the GCW Zero. It allows some games that run between 30 and 60 FPS, which display at 30 FPS with double-buffering, to emulate and display, as well as synthesise audio for, more frames per second.
- One of the commits builds MAME4ALL with -O3 and default toolchain flags instead of being explicit about MIPS-specific flags. This allows the toolchain's optimisations to evolve.
